### PR TITLE
Don't execute redirect for a child action

### DIFF
--- a/Source/Boilerplate.Web.Mvc5/Filters/RedirectToCanonicalUrlAttribute.cs
+++ b/Source/Boilerplate.Web.Mvc5/Filters/RedirectToCanonicalUrlAttribute.cs
@@ -71,7 +71,8 @@
                 throw new ArgumentNullException("filterContext");
             }
 
-            if (string.Equals(filterContext.HttpContext.Request.HttpMethod, "GET", StringComparison.Ordinal))
+            if (string.Equals(filterContext.HttpContext.Request.HttpMethod, "GET", StringComparison.Ordinal)
+                && !filterContext.IsChildAction)
             {
                 string canonicalUrl;
                 if (!this.TryGetCanonicalUrl(filterContext, out canonicalUrl))


### PR DESCRIPTION
When a view contains a child action: 

Html.RenderAction("actionName", "controllerName")

and the filter causes a redirect, an MVC error is thrown, "child actions are not allowed to perform redirect actions". This is because the filter looks at the attributes of the currently executing child controller, not the parent controller. If both don't have [NoLowercaseQueryString], the exception may be thrown.

Fix is to ignore execution of the redirect filter during child action execution.